### PR TITLE
Add basic waterfall chart plugin

### DIFF
--- a/packages/malloy-render/src/api/malloy-renderer.ts
+++ b/packages/malloy-render/src/api/malloy-renderer.ts
@@ -10,6 +10,7 @@ import type {RenderPluginFactory} from './plugin-types';
 import {MalloyViz} from './malloy-viz';
 import {LineChartPluginFactory} from '@/plugins/line-chart/line-chart-plugin';
 import {BarChartPluginFactory} from '@/plugins/bar-chart/bar-chart-plugin';
+import {WaterfallChartPluginFactory} from '@/plugins/waterfall-chart/waterfall-chart-plugin';
 
 export class MalloyRenderer {
   private globalOptions: MalloyRendererOptions;
@@ -20,6 +21,7 @@ export class MalloyRenderer {
     this.pluginRegistry = [
       LineChartPluginFactory,
       BarChartPluginFactory,
+      WaterfallChartPluginFactory,
       ...(options.plugins || []),
     ];
   }

--- a/packages/malloy-render/src/plugins/index.ts
+++ b/packages/malloy-render/src/plugins/index.ts
@@ -16,3 +16,8 @@ export {
   BarChartPluginFactory,
   type BarChartPluginInstance,
 } from './bar-chart/bar-chart-plugin';
+
+export {
+  WaterfallChartPluginFactory,
+  type WaterfallChartPluginInstance,
+} from './waterfall-chart/waterfall-chart-plugin';

--- a/packages/malloy-render/src/plugins/waterfall-chart/generate-waterfall_chart-vega-spec.ts
+++ b/packages/malloy-render/src/plugins/waterfall-chart/generate-waterfall_chart-vega-spec.ts
@@ -1,0 +1,107 @@
+import type {
+  MalloyDataToChartDataHandler,
+  VegaChartProps,
+} from '@/component/types';
+import {convertLegacyToVizTag} from '@/component/tag-utils';
+import type {RenderMetadata} from '@/component/render-result-metadata';
+import {Field, RepeatedRecordCell} from '@/data_tree';
+import type {RecordCell} from '@/data_tree';
+import type {Spec} from 'vega';
+import type {WaterfallChartPluginInstance} from './waterfall-chart-plugin';
+
+export function generateWaterfallChartVegaSpec(
+  metadata: RenderMetadata,
+  plugin: WaterfallChartPluginInstance
+): VegaChartProps {
+  const {field: explore} = plugin;
+  const settings = plugin.getMetadata().settings;
+  const tag = convertLegacyToVizTag(explore.tag);
+  const chartTag = tag.tag('viz');
+  if (!chartTag)
+    throw new Error(
+      'Malloy Waterfall Chart: Tried to render a waterfall chart, but no viz=waterfall tag was found'
+    );
+
+  const spec: Spec = {
+    $schema: 'https://vega.github.io/schema/vega/v5.json',
+    width: metadata.parentSize.width,
+    height: metadata.parentSize.height,
+    padding: 5,
+    data: [{name: 'values'}],
+    scales: [
+      {
+        name: 'x',
+        type: 'band',
+        domain: {data: 'values', field: 'x'},
+        range: 'width',
+        padding: 0.1,
+      },
+      {
+        name: 'y',
+        type: 'linear',
+        domain: {data: 'values', fields: ['start', 'end']},
+        nice: true,
+        range: 'height',
+      },
+    ],
+    axes: [
+      {scale: 'x', orient: 'bottom'},
+      {scale: 'y', orient: 'left'},
+    ],
+    marks: [
+      {
+        type: 'rect',
+        from: {data: 'values'},
+        encode: {
+          update: {
+            x: {scale: 'x', field: 'x'},
+            width: {scale: 'x', band: 1, offset: -1},
+            y: {scale: 'y', signal: 'max(datum.start, datum.end)'},
+            y2: {scale: 'y', signal: 'min(datum.start, datum.end)'},
+            fill: {value: '#1877F2'},
+          },
+        },
+      },
+    ],
+  };
+
+  const mapMalloyDataToChartData: MalloyDataToChartDataHandler = data => {
+    const records: {x: string; value: number; start: number; end: number}[] = [];
+
+    const startPath = Field.pathFromString(settings.startField);
+    const endPath = Field.pathFromString(settings.endField);
+    const xPath = Field.pathFromString(settings.xField);
+    const yPath = Field.pathFromString(settings.yField);
+    const nestPath = xPath.slice(0, -1);
+
+    for (const row of data.rows as RecordCell[]) {
+      const startVal = row.cellAt(startPath).value as number;
+      const endVal = row.cellAt(endPath).value as number;
+      let current = startVal;
+      records.push({x: 'start', value: startVal, start: 0, end: startVal});
+      const nested = row.cellAt(nestPath) as RepeatedRecordCell;
+      for (const nRow of nested.rows) {
+        const xVal = nRow.cellAt(xPath.slice(-1)).value;
+        const yVal = nRow.cellAt(yPath.slice(-1)).value as number;
+        const start = current;
+        const end = current + yVal;
+        records.push({x: String(xVal), value: yVal, start, end});
+        current = end;
+      }
+      records.push({x: 'end', value: endVal, start: 0, end: endVal});
+    }
+
+    return {data: records, isDataLimited: false};
+  };
+
+  return {
+    spec,
+    plotWidth: metadata.parentSize.width,
+    plotHeight: metadata.parentSize.height,
+    totalWidth: metadata.parentSize.width,
+    totalHeight: metadata.parentSize.height,
+    chartType: 'waterfall',
+    chartTag,
+    mapMalloyDataToChartData,
+  };
+}

--- a/packages/malloy-render/src/plugins/waterfall-chart/get-waterfall_chart-settings.ts
+++ b/packages/malloy-render/src/plugins/waterfall-chart/get-waterfall_chart-settings.ts
@@ -1,0 +1,50 @@
+import type {Tag} from '@malloydata/malloy-tag';
+import type {NestField} from '@/data_tree';
+import {Field} from '@/data_tree';
+import {convertLegacyToVizTag} from '@/component/tag-utils';
+import {type WaterfallChartSettings} from './waterfall-chart-settings';
+
+function getFieldPath(explore: NestField, ref: string): string {
+  let path: string[];
+  try {
+    path = Field.pathFromString(ref);
+  } catch {
+    path = [ref];
+  }
+  const field = explore.fieldAt(path);
+  return explore.pathTo(field);
+}
+
+export function getWaterfallChartSettings(
+  explore: NestField,
+  tagOverride?: Tag
+): WaterfallChartSettings {
+  const normalizedTag = convertLegacyToVizTag(tagOverride ?? explore.tag);
+  if (normalizedTag.text('viz') !== 'waterfall') {
+    throw new Error(
+      'Malloy Waterfall Chart: Tried to render a waterfall chart, but no viz=waterfall tag was found'
+    );
+  }
+
+  const vizTag = normalizedTag.tag('viz')!;
+
+  const startRef = vizTag.text('start');
+  const endRef = vizTag.text('end');
+  const xRef = vizTag.text('x');
+  const yRef = vizTag.text('y');
+
+  if (!startRef || !endRef || !xRef || !yRef) {
+    throw new Error(
+      'Malloy Waterfall Chart: start, end, x and y must be specified'
+    );
+  }
+
+  return {
+    startField: getFieldPath(explore, startRef),
+    endField: getFieldPath(explore, endRef),
+    xField: getFieldPath(explore, xRef),
+    yField: getFieldPath(explore, yRef),
+  };
+}
+
+export type {WaterfallChartSettings};

--- a/packages/malloy-render/src/plugins/waterfall-chart/settings-to-tag.ts
+++ b/packages/malloy-render/src/plugins/waterfall-chart/settings-to-tag.ts
@@ -1,0 +1,13 @@
+import {Tag} from '@malloydata/malloy-tag';
+import type {WaterfallChartSettings} from './waterfall-chart-settings';
+
+export function waterfallChartSettingsToTag(
+  settings: WaterfallChartSettings
+): Tag {
+  let tag = new Tag({properties: {viz: {eq: 'waterfall'}}});
+  if (settings.startField) tag = tag.set(['viz', 'start'], settings.startField);
+  if (settings.endField) tag = tag.set(['viz', 'end'], settings.endField);
+  if (settings.xField) tag = tag.set(['viz', 'x'], settings.xField);
+  if (settings.yField) tag = tag.set(['viz', 'y'], settings.yField);
+  return tag;
+}

--- a/packages/malloy-render/src/plugins/waterfall-chart/waterfall-chart-plugin.tsx
+++ b/packages/malloy-render/src/plugins/waterfall-chart/waterfall-chart-plugin.tsx
@@ -1,0 +1,132 @@
+import type {
+  RenderPluginFactory,
+  RenderProps,
+  CoreVizPluginInstance,
+} from '@/api/plugin-types';
+import {type Field, FieldType, type NestField} from '@/data_tree';
+import type {Tag} from '@malloydata/malloy-tag';
+import type {JSXElement} from 'solid-js';
+import {ChartV2} from '@/component/chart/chart-v2';
+import {
+  getWaterfallChartSettings,
+  type WaterfallChartSettings,
+} from './get-waterfall_chart-settings';
+import {generateWaterfallChartVegaSpec} from './generate-waterfall_chart-vega-spec';
+import {type VegaChartProps} from '@/component/types';
+import {type Config, parse, type Runtime} from 'vega';
+import {mergeVegaConfigs} from '@/component/vega/merge-vega-configs';
+import {baseVegaConfig} from '@/component/vega/base-vega-config';
+import type {
+  GetResultMetadataOptions,
+  RenderMetadata,
+} from '@/component/render-result-metadata';
+import {
+  defaultWaterfallChartSettings,
+  waterfallChartSettingsSchema,
+} from './waterfall-chart-settings';
+import {waterfallChartSettingsToTag} from './settings-to-tag';
+
+interface WaterfallChartPluginMetadata {
+  type: 'waterfall';
+  field: NestField;
+  settings: WaterfallChartSettings;
+}
+
+export interface WaterfallChartPluginInstance
+  extends CoreVizPluginInstance<WaterfallChartPluginMetadata> {
+  field: NestField;
+}
+
+export const WaterfallChartPluginFactory: RenderPluginFactory<WaterfallChartPluginInstance> = {
+  name: 'waterfall',
+
+  matches: (field: Field, fieldTag: Tag, fieldType: FieldType): boolean => {
+    const hasTag = fieldTag.has('viz') && fieldTag.text('viz') === 'waterfall';
+    const isRepeatedRecord = fieldType === FieldType.RepeatedRecord;
+    if (hasTag && !isRepeatedRecord) {
+      throw new Error(
+        'Malloy Waterfall Chart: field is a waterfall chart, but is not a repeated record'
+      );
+    }
+    return hasTag && isRepeatedRecord;
+  },
+
+  create: (field: Field): WaterfallChartPluginInstance => {
+    if (!field.isNest()) {
+      throw new Error('Waterfall chart: must be a nest field');
+    }
+
+    let settings: WaterfallChartSettings;
+    let runtime: Runtime | undefined;
+    let vegaProps: VegaChartProps | undefined;
+
+    try {
+      settings = getWaterfallChartSettings(field);
+    } catch (error) {
+      throw new Error(`Waterfall chart settings error: ${error.message}`);
+    }
+
+    const pluginInstance: WaterfallChartPluginInstance = {
+      name: 'waterfall',
+      field,
+      renderMode: 'solidjs',
+      sizingStrategy: 'fill',
+
+      renderComponent: (props: RenderProps): JSXElement => {
+        if (!runtime || !vegaProps) {
+          throw new Error('Malloy Waterfall Chart: missing Vega runtime');
+        }
+        if (!props.dataColumn.isRepeatedRecord()) {
+          throw new Error('Malloy Waterfall Chart: data column is not a repeated record');
+        }
+
+        const mappedData = vegaProps.mapMalloyDataToChartData(props.dataColumn);
+
+        return (
+          <ChartV2
+            data={props.dataColumn}
+            values={mappedData.data}
+            runtime={runtime}
+            vegaSpec={vegaProps.spec}
+            plotWidth={vegaProps.plotWidth}
+            plotHeight={vegaProps.plotHeight}
+            totalWidth={vegaProps.totalWidth}
+            totalHeight={vegaProps.totalHeight}
+            chartTag={vegaProps.chartTag}
+            isDataLimited={mappedData.isDataLimited}
+            dataLimitMessage={mappedData.dataLimitMessage}
+          />
+        );
+      },
+
+      beforeRender: (
+        metadata: RenderMetadata,
+        options: GetResultMetadataOptions
+      ): void => {
+        vegaProps = generateWaterfallChartVegaSpec(metadata, pluginInstance);
+        const vegaConfig: Config = mergeVegaConfigs(
+          baseVegaConfig(),
+          options.getVegaConfigOverride?.('waterfall') ?? {}
+        );
+        runtime = parse(vegaProps.spec, vegaConfig);
+      },
+
+      getMetadata: (): WaterfallChartPluginMetadata => ({
+        type: 'waterfall',
+        field,
+        settings,
+      }),
+
+      getSchema: () => waterfallChartSettingsSchema,
+      getSettings: () => settings,
+      getDefaultSettings: () => defaultWaterfallChartSettings,
+      settingsToTag: (settings: Record<string, unknown>) => {
+        return waterfallChartSettingsToTag(settings as WaterfallChartSettings);
+      },
+    };
+
+    return pluginInstance;
+  },
+};
+
+export type {WaterfallChartPluginInstance};

--- a/packages/malloy-render/src/plugins/waterfall-chart/waterfall-chart-settings.ts
+++ b/packages/malloy-render/src/plugins/waterfall-chart/waterfall-chart-settings.ts
@@ -1,0 +1,35 @@
+import type {JSONSchemaObject} from '@/api/json-schema-types';
+
+export interface WaterfallChartSettings {
+  startField: string;
+  endField: string;
+  xField: string;
+  yField: string;
+}
+
+export const defaultWaterfallChartSettings: WaterfallChartSettings = {
+  startField: '',
+  endField: '',
+  xField: '',
+  yField: '',
+};
+
+export interface IWaterfallChartSettingsSchema extends JSONSchemaObject {
+  properties: {
+    startField: {type: 'string'};
+    endField: {type: 'string'};
+    xField: {type: 'string'};
+    yField: {type: 'string'};
+  };
+}
+
+export const waterfallChartSettingsSchema: IWaterfallChartSettingsSchema = {
+  title: 'Waterfall Chart Settings',
+  type: 'object',
+  properties: {
+    startField: {type: 'string', subtype: 'field'},
+    endField: {type: 'string', subtype: 'field'},
+    xField: {type: 'string', subtype: 'field'},
+    yField: {type: 'string', subtype: 'field'},
+  },
+};


### PR DESCRIPTION
## Summary
- implement a new Waterfall chart plugin under `malloy-render`
- expose the plugin from the plugin index
- register the plugin in `MalloyRenderer`

## Testing
- `npx tsc -p packages/malloy-render/tsconfig.json` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_685e95d9ffac8325b24686cfceb1960e